### PR TITLE
Cannot read property 'toString' of null #49

### DIFF
--- a/_assets/javascripts/splash.js
+++ b/_assets/javascripts/splash.js
@@ -178,7 +178,7 @@ if (window && window.outerWidth && window.outerWidth > 700) {
               }
             }
           });
-        }, 25);
+        }, 400);
       }
     }
   });


### PR DESCRIPTION
Increased the timeout delay to allow for the data to load before viz.setModel state change is called. On slower connections the time model property _this.model.time.value does not exist yet when the toString() function is being called.

See screen shot of where this actually happens. Maybe adding a check in that code with a default value should be best solution. 

![screen shot 2017-07-22 at 7 13 16 pm](https://user-images.githubusercontent.com/2431857/28495087-d9f39c5a-6f10-11e7-9320-06e399949fca.png)
